### PR TITLE
🗃 Open Vault Catalog

### DIFF
--- a/catalog.ipynb
+++ b/catalog.ipynb
@@ -1,0 +1,54 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from csv import DictReader\n",
+    "\n",
+    "with open('ov_catalog.csv') as f:\n",
+    "    csv = DictReader(f)\n",
+    "    catalog = list(csv)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from organ.db import engine\n",
+    "from sqlmodel import Session\n",
+    "from organ.models import OpenVaultCatalog\n",
+    "\n",
+    "with Session(engine) as session:\n",
+    "    for item in catalog:\n",
+    "        session.add(OpenVaultCatalog(**item))\n",
+    "    session.commit()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/organ/api.py
+++ b/organ/api.py
@@ -1,7 +1,9 @@
+from fastapi import Depends
 from fastcrud import crud_router
 
 from organ.db import get_async_session
 from organ.models import OpenVaultCatalog, Organization, OrganizationSchema
+from organ.oauth import is_user_authenticated
 
 orgs = crud_router(
     model=Organization,
@@ -19,4 +21,11 @@ ov_catalog = crud_router(
     tags=['ov'],
     create_schema=OpenVaultCatalog,
     update_schema=OpenVaultCatalog,
+    create_deps=[Depends(is_user_authenticated)],
+    read_deps=None,
+    read_multi_deps=[Depends(is_user_authenticated)],
+    read_paginated_deps=[Depends(is_user_authenticated)],
+    update_deps=[Depends(is_user_authenticated)],
+    delete_deps=[Depends(is_user_authenticated)],
+    db_delete_deps=[Depends(is_user_authenticated)],
 )

--- a/organ/app.py
+++ b/organ/app.py
@@ -9,9 +9,9 @@ from starlette.routing import RedirectResponse, Route
 from starlette_admin.contrib.sqlmodel import Admin
 
 from organ._version import __version__
+from organ.api import orgs, ov_catalog
 from organ.auth import OAuthProvider
 from organ.config import ORGAN_SECRET
-from organ.crud import orgs, ov_catalog
 from organ.db import engine
 from organ.models import OpenVaultCatalog, Organization, User
 from organ.oauth import is_user_authenticated, oauth_config, on_auth
@@ -41,7 +41,7 @@ app.include_router(oauth2_router, tags=["auth"])
 app.add_middleware(OAuth2Middleware, config=oauth_config, callback=on_auth)
 app.add_middleware(SessionMiddleware, secret_key=ORGAN_SECRET)
 app.include_router(orgs, dependencies=[Depends(is_user_authenticated)])
-app.include_router(ov_catalog, dependencies=[Depends(is_user_authenticated)])
+app.include_router(ov_catalog)
 
 # Add static files
 app.mount("/static", StaticFiles(directory="static"), name="static")

--- a/organ/app.py
+++ b/organ/app.py
@@ -11,11 +11,11 @@ from starlette_admin.contrib.sqlmodel import Admin
 from organ._version import __version__
 from organ.auth import OAuthProvider
 from organ.config import ORGAN_SECRET
-from organ.crud import orgs
+from organ.crud import orgs, ov_catalog
 from organ.db import engine
-from organ.models import Organization, User
+from organ.models import OpenVaultCatalog, Organization, User
 from organ.oauth import is_user_authenticated, oauth_config, on_auth
-from organ.views import OrganizationView, UserView
+from organ.views import OpenVaultCatalogView, OrganizationView, UserView
 
 
 def init_db():
@@ -41,6 +41,7 @@ app.include_router(oauth2_router, tags=["auth"])
 app.add_middleware(OAuth2Middleware, config=oauth_config, callback=on_auth)
 app.add_middleware(SessionMiddleware, secret_key=ORGAN_SECRET)
 app.include_router(orgs, dependencies=[Depends(is_user_authenticated)])
+app.include_router(ov_catalog, dependencies=[Depends(is_user_authenticated)])
 
 # Add static files
 app.mount("/static", StaticFiles(directory="static"), name="static")
@@ -58,5 +59,6 @@ admin = Admin(
 # Add views
 admin.add_view(UserView(User, icon="fa fa-users"))
 admin.add_view(OrganizationView(Organization, icon="fa fa-box"))
+admin.add_view(OpenVaultCatalogView(OpenVaultCatalog, icon="fa fa-vault"))
 
 admin.mount_to(app)

--- a/organ/crud.py
+++ b/organ/crud.py
@@ -1,7 +1,7 @@
 from fastcrud import crud_router
 
 from organ.db import get_async_session
-from organ.models import Organization, OrganizationSchema
+from organ.models import OpenVaultCatalog, Organization, OrganizationSchema
 
 orgs = crud_router(
     model=Organization,
@@ -10,4 +10,13 @@ orgs = crud_router(
     tags=['orgs'],
     create_schema=OrganizationSchema,
     update_schema=OrganizationSchema,
+)
+
+ov_catalog = crud_router(
+    model=OpenVaultCatalog,
+    session=get_async_session,
+    path='/ov',
+    tags=['ov'],
+    create_schema=OpenVaultCatalog,
+    update_schema=OpenVaultCatalog,
 )

--- a/organ/models.py
+++ b/organ/models.py
@@ -14,6 +14,8 @@ Url = Annotated[
 
 
 class OrganizationSchema(SQLModel):
+    id: str | None = Field(default=None, index=True)
+
     name: str = Field(
         default=None, index=True, schema_extra={"validation_alias": "Name"}
     )
@@ -35,12 +37,10 @@ class OrganizationSchema(SQLModel):
 
     longitude: float | None = Field(default=None, index=True)
 
-    ovid: str | None = Field(default=None, index=True)
-
 
 class Organization(OrganizationSchema, table=True):
     __tablename__ = "organizations"
-    id: int | None = Field(default=None, primary_key=True)
+    id: str | None = Field(default=None, index=True, primary_key=True)
     uid: UUID = Field(index=True, default_factory=uuid4, unique=True)
 
 
@@ -53,3 +53,9 @@ class User(SQLModel, table=True):
 
     async def __admin_repr__(self, request: Request):
         return self.display_name
+
+
+class OpenVaultCatalog(SQLModel, table=True):
+    __tablename__ = "ov_guids"
+    ovid: str = Field(primary_key=True, index=True)
+    guid: str = Field(index=True)

--- a/organ/views.py
+++ b/organ/views.py
@@ -5,7 +5,6 @@ from organ.fields import ShowImageField, ShowOrgLogoField
 
 
 class OrganizationView(ModelView):
-    # page_size_options = [5, 10, 25, -1]
     fields = [
         'id',
         'name',
@@ -19,7 +18,6 @@ class OrganizationView(ModelView):
         'longitude',
         'about',
         'productions',
-        'ovid',
         'uid',
     ]
 
@@ -36,3 +34,7 @@ class UserView(ModelView):
             'avatar_url', label='Avatar', display_template="displays/show_image.html"
         ),
     ]
+
+
+class OpenVaultCatalogView(ModelView):
+    label = 'Open Vault Catalog'


### PR DESCRIPTION
# `OpenVaultCatalog`
Adds Open Vault Catalog
- model
- view
- crud `/ov/`
- auth
  - `GET /ov/get/{id}` is open to unauthenticated traffic
  - All other routes protected 
 